### PR TITLE
Remove return characters for json parsing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -52,6 +52,6 @@ with serial.Serial(INTERFACE, 115200, timeout=1) as ser:
 		match = re.match(regex, line)
 
 		if match:
-			percent = match.group(1)
-			timeLeft = match.group(2)
+			percent = match.group(1).rstrip()
+			timeLeft = match.group(2).rstrip()
 			sendToHA(percent, timeLeft)


### PR DESCRIPTION
raw string included \r return characters, using rstrip removes these allowing the string to be directly parsed as integers.